### PR TITLE
Abstract displaz command to make it user-configurable.

### DIFF
--- a/src/Displaz.jl
+++ b/src/Displaz.jl
@@ -6,6 +6,8 @@ using Colors
 export plot3d, plot3d!, clearplot, viewplot
 export KeyEvent, CursorPosition, event_loop
 
+displaz_cmd() = get(ENV, "DISPLAZ_CMD", "displaz")
+
 # Convert julia array into a type name and type appropriate for putting in the
 # ply header
 ply_type_convert(a::AbstractArray{UInt8})    = ("uint8",   a)
@@ -300,7 +302,7 @@ function plot3d(plotobj::DisplazWindow, position; color=[1,1,1], markersize=[0.1
         label = "$seriestype [$nvertices vertices]"
     end
     addopt = _overwrite_label ? [] : "-add"
-    run(`displaz -script $addopt -server $(plotobj.name) -label $label -shader generic_points.glsl -rmtemp $filename`)
+    run(`$(displaz_cmd()) -script $addopt -server $(plotobj.name) -label $label -shader generic_points.glsl -rmtemp $filename`)
     nothing
 end
 
@@ -336,7 +338,7 @@ using unix shell glob pattern syntax.
 """
 function clearplot(plotobj::DisplazWindow, patterns...)
     unload_args = isempty(patterns) ? ["-clear"] : ["-unload", patterns...]
-    run(`displaz -script -server $(plotobj.name) $unload_args`)
+    run(`$(displaz_cmd()) -script -server $(plotobj.name) $unload_args`)
     nothing
 end
 clearplot(patterns...) = clearplot(current(), patterns...)
@@ -368,7 +370,7 @@ function viewplot(plotobj::DisplazWindow;
     center_args   = viewplot_center_args(center)
     radius_args   = viewplot_radius_args(radius)
     rotation_args = viewplot_rotation_args(rotation)
-    run(`displaz -script -server $(plotobj.name) $center_args $radius_args $rotation_args`)
+    run(`$(displaz_cmd()) -script -server $(plotobj.name) $center_args $radius_args $rotation_args`)
     nothing
 end
 viewplot(; kwargs...) = viewplot(current(); kwargs...)

--- a/src/events.jl
+++ b/src/events.jl
@@ -48,7 +48,7 @@ end
 function event_loop(callback::Function, event_list...)
     hookopts = [["-hook", _eventspec_str(e), _argspec_str(p)]
                 for (e,p) in event_list]
-    stdout,stdin,proc = readandwrite(`displaz $(vcat(hookopts...))`)
+    stdout,stdin,proc = readandwrite(`$(displaz_cmd()) $(vcat(hookopts...))`)
     while true
         rawline = readline(stdout)
         line = split(rawline)


### PR DESCRIPTION
The user can set an environment variable (DISPLAZ_CMD) to specify the path to
the displaz executable. The environment variable is checked on each invocation,
defaulting to `displaz` if it is undefined.
