### PR TITLE
Added mutate function and extended StaticArray support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,18 @@ To plot a set of 5 vertices, and line series between a subset of these vertices:
 ```julia
 using Displaz
 using Colors
-using FixedSizeArrays
+using StaticArrays
 
 # Clear plots
 clearplot()
 
 N = 5
 # Random points
-position = rand(Point{3,Float64}, N)
+position = rand(SVector{3,Float64}, N)
 # Plot points
 plot3d!(position, color=[Gray{Float64}(i/N) for i=1:N], label="Example3 Points")
 # Plot a pair of line series between vertices 1:2 and 3:5
 plot3d!(position, color="r", linebreak=[1,3], markershape="-", label="Example3 Lines")
+# mutate the color of the first two points (efficient for modifying a subset of points)
+Displaz.mutate!("Example3 Points", 1:2; color = [Gray{Float64}(1.0)])
 ```
-

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
-julia 0.4
-FixedSizeArrays 0.0.8
+julia 0.5
+StaticArrays
 Colors
-Compat 0.8

--- a/src/Displaz.jl
+++ b/src/Displaz.jl
@@ -7,10 +7,14 @@ using Colors
 export plot3d, plot3d!, plotimage, plotimage!, clearplot, viewplot
 export KeyEvent, CursorPosition, event_loop
 
-if VERSION > v"0.5-" # Interop with StaticArrays
-    using StaticArrays
-else # Interop with FixedSizeArrays
+_use_FixedSizeArrays = VERSION < v"0.5-" || Pkg.installed("FixedSizeArrays") != nothing
+_use_StaticArrays = VERSION > v"0.5-"  # Or detect installation?
+
+if _use_FixedSizeArrays
     using FixedSizeArrays
+end
+if _use_StaticArrays
+    using StaticArrays
 end
 
 """
@@ -169,7 +173,7 @@ interpret_linebreak(nvertices, linebreak) = linebreak
 interpret_linebreak(nvertices, i::Integer) = i == 1 ? [1] : 1:i:nvertices
 
 interpret_position(pos::AbstractMatrix) = pos
-@static if VERSION > v"0.5-"
+if _use_StaticArrays
     function interpret_position{V <: StaticVector}(pos::AbstractVector{V})
         size(eltype(pos)) == (3,) || error("position should be a 3-vector")
         T = eltype(V)
@@ -177,7 +181,8 @@ interpret_position(pos::AbstractMatrix) = pos
         nvertices = length(pos)
         return reinterpret(T, pos, (3, nvertices))
     end
-else
+end
+if _use_FixedSizeArrays
     function interpret_position{V <: FixedVector{3}}(pos::AbstractVector{V})
         T = eltype(V)
         isbits(T) || error("Can't reinterpret position with elements $T")

--- a/src/Displaz.jl
+++ b/src/Displaz.jl
@@ -358,11 +358,10 @@ function plot3d(plotobj::DisplazWindow, position; color=[1,1,1], markersize=[0.1
 end
 
 
-
 """
-    mutate!([plotobj,] index; attr1=value1, ...))
+    mutate!([plotobj,] label, index; attr1=value1, ...))
 
-Mutate the data in an existing displaz data set, for instance to change the
+Mutate the data in an existing displaz data set `label`, for instance to change the
 position or other attribute of a subset of points (with the advantage of
 reducing the amount of communication between Julia and displaz, and therefore
 increasing speed).
@@ -372,13 +371,12 @@ increasing speed).
 `position` attribute controls the vertex positions, and the remainder match
 the original plotting command.
 """
-function mutate!{I <: Integer}(index::AbstractVector{I}; label = nothing, kwargs...)
+function mutate!{I <: Integer}(label::AbstractString, index::AbstractVector{I}; kwargs...)
     plotobj = _current_figure
-    mutate!(plotobj, index; label = label, kwargs...)
+    mutate!(plotobj, label, index; kwargs...)
 end
 
-
-function mutate!{I <: Integer}(plotobj::DisplazWindow, index::AbstractVector{I}; label = nothing, kwargs...)
+function mutate!{I <: Integer}(plotobj::DisplazWindow, label::AbstractString, index::AbstractVector{I}; kwargs...)
     nvertices = length(index)
 
     fields = Vector{Any}()
@@ -429,19 +427,11 @@ function mutate!{I <: Integer}(plotobj::DisplazWindow, index::AbstractVector{I};
 
     filename = tempname()*".ply"
 
-    if label === nothing
-        seriestype = "Points"
-        label = "$seriestype [$nvertices vertices]"
-    end
-
     write_ply_points(filename, nvertices, fields)
     run(`$_displaz_cmd -script -modify -server $(plotobj.name) -label $label -shader generic_points.glsl $filename`)
     nothing
 
 end
-
-
-
 
 
 """

--- a/src/Displaz.jl
+++ b/src/Displaz.jl
@@ -1,11 +1,17 @@
 __precompile__()
 
 module Displaz
-using FixedSizeArrays
+using Compat
 using Colors
 
 export plot3d, plot3d!, plotimage, plotimage!, clearplot, viewplot
 export KeyEvent, CursorPosition, event_loop
+
+if VERSION > v"0.5-" # Interop with StaticArrays
+    using StaticArrays
+else # Interop with FixedSizeArrays
+    using FixedSizeArrays
+end
 
 """
     set_displaz_cmd(cmd)
@@ -162,6 +168,24 @@ interpret_shape(s::AbstractString) = Int[_shape_ids[c] for c in s]
 interpret_linebreak(nvertices, linebreak) = linebreak
 interpret_linebreak(nvertices, i::Integer) = i == 1 ? [1] : 1:i:nvertices
 
+interpret_position(pos::AbstractMatrix) = pos
+@static if VERSION > v"0.5-"
+    function interpret_position{V <: StaticVector}(pos::AbstractVector{V})
+        size(eltype(pos)) == (3,) || error("position should be a 3-vector")
+        T = eltype(V)
+        isbits(T) || error("Can't reinterpret position with elements $T")
+        nvertices = length(pos)
+        return reinterpret(T, pos, (3, nvertices))
+    end
+else
+    function interpret_position{V <: FixedVector{3}}(pos::AbstractVector{V})
+        T = eltype(V)
+        isbits(T) || error("Can't reinterpret position with elements $T")
+        nvertices = length(pos)
+        return reinterpret(T, pos, (3, nvertices))
+    end
+end
+
 # Multiple figure window support
 # TODO: Consider how the API below relates to Plots.jl and its tendency to
 # create a lot of new figure windows rather than clearing existing ones.
@@ -276,6 +300,7 @@ is the initial index of a line segment.
 """
 function plot3d(plotobj::DisplazWindow, position; color=[1,1,1], markersize=[0.1], markershape=[0],
                 label=nothing, linebreak=[1], _overwrite_label=false, kwargs...)
+    position = interpret_position(position)
     nvertices = size(position, 2)
     color = interpret_color(color)
     linebreak = interpret_linebreak(nvertices, linebreak)
@@ -327,9 +352,92 @@ function plot3d(plotobj::DisplazWindow, position; color=[1,1,1], markersize=[0.1
     nothing
 end
 
-# Interop with FixedSizeArrays.
-plot3d{V<:FixedVector{3}}(plotobj::DisplazWindow, position::Vector{V}; kwargs...) =
-    plot3d(plotobj, destructure(position); kwargs...)
+
+
+"""
+    mutate!([plotobj,] index; attr1=value1, ...))
+
+Mutate the data in an existing displaz data set, for instance to change the
+position or other attribute of a subset of points (with the advantage of
+reducing the amount of communication between Julia and displaz, and therefore
+increasing speed).
+
+`index` is vector of indices with reference to the original plot. The attribute
+`label` is used to match with the correct data set within displaz. The
+`position` attribute controls the vertex positions, and the remainder match
+the original plotting command.
+"""
+function mutate!{I <: Integer}(index::AbstractVector{I}; label = nothing, kwargs...)
+    plotobj = _current_figure
+    mutate!(plotobj, index; label = label, kwargs...)
+end
+
+
+function mutate!{I <: Integer}(plotobj::DisplazWindow, index::AbstractVector{I}; label = nothing, kwargs...)
+    nvertices = length(index)
+
+    fields = Vector{Any}()
+
+    push!(fields, (:index, array_semantic, map(UInt32, (index-1)'))) # It turns out the -1 is rather important (0-based indexing)... :)
+
+    for (fieldname, fielddata) ∈ kwargs
+        if fieldname == :position
+            fielddaata = interpret_position(fielddata)
+            size(fielddata) == (3,nvertices) || error("position must be a 3x$nvertices array")
+
+            push!(fields, (:position, vector_semantic, fielddata))
+        elseif fieldname == :color
+            fielddata = interpret_color(fielddata)
+            size(fielddata, 1) == 3 || error("color must be a 3xN array")
+            if size(fielddata,2) == 1
+                fielddata = repmat(fielddata, 1, nvertices)
+            end
+            size(fielddata) == (3,nvertices,) || error("wrong number of color points")
+            fielddata = map(Float32, fielddata)
+
+            push!(fields, (:color, color_semantic, fielddata))
+        elseif fieldname == :markershape
+            if length(fielddata) == 1
+                fielddata = repmat(fielddata, 1, nvertices)
+            end
+            size(fielddata) == (nvertices,) || error("wrong number of markershape points")
+            fielddata = interpret_shape(fielddata)
+
+            push!(fields, (:markershape, array_semantic, vec(fielddata)'))
+        elseif fieldname == :linebreak
+            if length(fielddata) == 1
+                fielddata = repmat(fielddata, 1, nvertices)
+            end
+            fielddata = interpret_linebreak(fielddata)
+
+            push!(fields, (:linebreak, array_semantic, vec(fielddata)'))
+        else
+            if length(fielddata) == 1
+                fielddata = repmat(fielddata, nvertices)
+            end
+            size(fielddata) == (nvertices,) || error("extra fields must be vectors of same length as index array")
+            fielddata = map(Float32, fielddata)
+
+            push!(fields, (fieldname, array_semantic, vec(fielddata)'))
+        end
+    end
+
+    filename = tempname()*".ply"
+
+    if label === nothing
+        seriestype = "Points"
+        label = "$seriestype [$nvertices vertices]"
+    end
+
+    write_ply_points(filename, nvertices, fields)
+    run(`$_displaz_cmd -script -modify -server $(plotobj.name) -label $label -shader generic_points.glsl $filename`)
+    nothing
+
+end
+
+
+
+
 
 """
 Overwrite points or lines with the same label on the 3D plot

--- a/src/Displaz.jl
+++ b/src/Displaz.jl
@@ -1,7 +1,6 @@
 __precompile__()
 
 module Displaz
-using Compat
 using Colors
 
 export plot3d, plot3d!, plotimage, plotimage!, clearplot, viewplot

--- a/src/Displaz.jl
+++ b/src/Displaz.jl
@@ -1,20 +1,11 @@
 __precompile__()
 
 module Displaz
+using StaticArrays
 using Colors
 
 export plot3d, plot3d!, plotimage, plotimage!, clearplot, viewplot
 export KeyEvent, CursorPosition, event_loop
-
-_use_FixedSizeArrays = VERSION < v"0.5-" || Pkg.installed("FixedSizeArrays") != nothing
-_use_StaticArrays = VERSION > v"0.5-"  # Or detect installation?
-
-if _use_FixedSizeArrays
-    using FixedSizeArrays
-end
-if _use_StaticArrays
-    using StaticArrays
-end
 
 """
     set_displaz_cmd(cmd)
@@ -172,22 +163,12 @@ interpret_linebreak(nvertices, linebreak) = linebreak
 interpret_linebreak(nvertices, i::Integer) = i == 1 ? [1] : 1:i:nvertices
 
 interpret_position(pos::AbstractMatrix) = pos
-if _use_StaticArrays
-    function interpret_position{V <: StaticVector}(pos::AbstractVector{V})
-        size(eltype(pos)) == (3,) || error("position should be a 3-vector")
-        T = eltype(V)
-        isbits(T) || error("Can't reinterpret position with elements $T")
-        nvertices = length(pos)
-        return reinterpret(T, pos, (3, nvertices))
-    end
-end
-if _use_FixedSizeArrays
-    function interpret_position{V <: FixedVector{3}}(pos::AbstractVector{V})
-        T = eltype(V)
-        isbits(T) || error("Can't reinterpret position with elements $T")
-        nvertices = length(pos)
-        return reinterpret(T, pos, (3, nvertices))
-    end
+function interpret_position{V <: StaticVector}(pos::AbstractVector{V})
+    size(eltype(pos)) == (3,) || error("position should be a 3-vector")
+    T = eltype(V)
+    isbits(T) || error("Can't reinterpret position with elements $T")
+    nvertices = length(pos)
+    return reinterpret(T, pos, (3, nvertices))
 end
 
 # Multiple figure window support

--- a/src/events.jl
+++ b/src/events.jl
@@ -7,9 +7,14 @@ end
 import Base: ==
 ==(e1::KeyEvent, e2::KeyEvent) = e1.spec == e2.spec
 
-
-immutable CursorPosition
-    pos::Point{3,Float64}
+@static if VERSION > v"0.5-"
+    immutable CursorPosition
+        pos::SVector{3,Float64}
+    end
+else
+    immutable CursorPosition
+        pos::Point{3,Float64}
+    end
 end
 
 

--- a/src/events.jl
+++ b/src/events.jl
@@ -7,16 +7,9 @@ end
 import Base: ==
 ==(e1::KeyEvent, e2::KeyEvent) = e1.spec == e2.spec
 
-@static if VERSION > v"0.5-"
-    immutable CursorPosition
-        pos::SVector{3,Float64}
-    end
-else
-    immutable CursorPosition
-        pos::Point{3,Float64}
-    end
+immutable CursorPosition
+    pos::SVector{3,Float64}
 end
-
 
 _eventspec_str(s::AbstractString) = s
 _eventspec_str(e::KeyEvent) = "key:$(e.spec)"


### PR DESCRIPTION
The `Displaz.mutate!` function is defined to work with the new ability to update a subset of vertices. This makes interactive applications signficantly faster (load delay scales with number of changed points`*`changed fields not total number of points`*`all fields, plus it avoids sorting and reordering and some reallocation).

The package now uses only _FixedSizeArrays_ in 0.4 and only _StaticArrays_ in 0.5. Not sure how we should manage the REQUIRE for that (can you do conditional statements in REQUIRE?)

(Probably should merge displaz's mutate branch before this one).
