### PR TITLE
update to julia 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
+  - 1.0
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.5
+julia 0.7
 StaticArrays
 Colors

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,17 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 1.0
+  - julia_version: nightly
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# # Uncomment the following lines to allow failures on nightly julia
+# # (tests will run but not make your overall status red)
+# matrix:
+#   allow_failures:
+#   - julia_version: nightly
 
 branches:
   only:
@@ -17,18 +25,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"Displaz\"); Pkg.build(\"Displaz\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia --check-bounds=yes -e "Pkg.test(\"Displaz\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,14 +1,11 @@
-using Compat
-
-
 function displaz_version()
     displaz_cmd = get(ENV, "DISPLAZ_CMD", "displaz")
     try
-        verstring = readstring(`$displaz_cmd -version`)
-        m = match(r"version *(.*)-g.*", verstring)
-        VersionNumber(m[1])
+        verstring = read(`$displaz_cmd -version`, String)
+        m = match(r"version *([\d\.]*)-?", verstring)
+        VersionNumber(m.captures[1])
     catch err
-        warn(err)
+        @warn(err)
         nothing
     end
 end
@@ -16,7 +13,7 @@ end
 ver = displaz_version()
 
 if ver === nothing
-    warn(
+    @warn(
         """
         displaz could not be found - please check that you have it installed
         (for now, you will need to build it from source - see
@@ -26,7 +23,7 @@ if ver === nothing
         """
     )
 elseif ver < v"0.3.1-317"
-    warn(
+    @warn(
         """
         You have an older version ($ver) of displaz.  You should upgrade
         to the latest version to ensure the Displaz.jl bindings work correctly.

--- a/examples/point_spiral.jl
+++ b/examples/point_spiral.jl
@@ -1,13 +1,13 @@
 using Displaz
 
 function example(N)
-    t = linspace(0,1, N)'
-    P = (10.+0.2*rand(size(t))) .* vcat(exp(5*t).*cos(100*pi*t),
-                                        exp(5*t).*sin(100*pi*t),
-                                        100*t);
-    C = vcat(t, 1.-t, zeros(t));
+    t = range(0, stop=1, length=N)'
+    P = (10 .+ 0.2*rand(Float64, size(t))) .* vcat(exp.(5*t).*cos.(100*pi*t),
+                                                   exp.(5*t).*sin.(100*pi*t),
+                                                   100*t);
+    C = vcat(t, 1 .- t, zero(t));
     sz  = map(Float32, t)
-    shape = mod(rand(UInt8, N), 6)
+    shape = mod.(rand(UInt8, N), 6)
     plot3d!(P, color = C, label="Top series", markershape=shape)
     P[3,:] = -P[3,:]
     plot3d!(P, color = C, markersize = sz, markershape="-", label="Bottom series")

--- a/src/Displaz.jl
+++ b/src/Displaz.jl
@@ -1,5 +1,3 @@
-__precompile__()
-
 module Displaz
 using StaticArrays
 using Colors
@@ -31,9 +29,9 @@ ply_type_convert(a::AbstractArray{Int32})    = ("int32",   a)
 ply_type_convert(a::AbstractArray{Float32})  = ("float32", a)
 ply_type_convert(a::AbstractArray{Float64})  = ("float64", a)
 # Generic cases - actually do a conversion
-ply_type_convert{T<:Unsigned}(a::AbstractArray{T}) = ("uint32",  map(UInt32,a))
-ply_type_convert{T<:Integer }(a::AbstractArray{T}) = ("int32",   map(Int32,a))
-ply_type_convert{T<:Real    }(a::AbstractArray{T}) = ("float64", map(Float64,a))
+ply_type_convert(a::AbstractArray{T}) where T <: Unsigned = ("uint32",  map(UInt32,a))
+ply_type_convert(a::AbstractArray{T}) where T <: Integer = ("int32",   map(Int32,a))
+ply_type_convert(a::AbstractArray{T}) where T <: Real = ("float64", map(Float64,a))
 
 
 const array_semantic = 0
@@ -60,7 +58,7 @@ function write_ply_points(filename, nvertices, fields)
         write(fid, "comment Displaz native\n")
         for ((name,semantic,_), (typename, value)) in zip(fields, converted_fields)
             n = size(value,2)
-            assert(n == nvertices || n == 1)
+            @assert(n == nvertices || n == 1)
             write(fid, "element vertex_$name $n\n")
             for i = 1:size(value,1)
                 propname = ply_property_name(semantic, i)
@@ -143,7 +141,7 @@ interpret_color(s::AbstractString) = length(s) == 1 ? interpret_color(s[1]) : er
 interpret_color(c::Char) = _color_names[c]
 interpret_color(c::AbstractRGB) = [red(c), green(c), blue(c)]
 interpret_color(c::Color) = interpret_color(RGB(c))
-function interpret_color{T<:Color}(cs::AbstractVector{T})
+function interpret_color(cs::AbstractVector{T}) where T <: Color
     a = zeros(eltype(T), (3,length(cs)))
     for i=1:length(cs)
         c = RGB(cs[i])
@@ -163,12 +161,12 @@ interpret_linebreak(nvertices, linebreak) = linebreak
 interpret_linebreak(nvertices, i::Integer) = i == 1 ? [1] : 1:i:nvertices
 
 interpret_position(pos::AbstractMatrix) = pos
-function interpret_position{V <: StaticVector}(pos::AbstractVector{V})
+function interpret_position(pos::AbstractVector{V}) where V <: StaticVector
     size(eltype(pos)) == (3,) || error("position should be a 3-vector")
     T = eltype(V)
-    isbits(T) || error("Can't reinterpret position with elements $T")
+    isbitstype(T) || error("Can't reinterpret position with elements $T")
     nvertices = length(pos)
-    return reinterpret(T, pos, (3, nvertices))
+    return reshape(reinterpret(T, pos), (3, nvertices))
 end
 
 function interpret_position(pos::AbstractVector{T}) where T <: Real
@@ -179,7 +177,7 @@ end
 # Multiple figure window support
 # TODO: Consider how the API below relates to Plots.jl and its tendency to
 # create a lot of new figure windows rather than clearing existing ones.
-type DisplazWindow
+mutable struct DisplazWindow
     name::AbstractString
 end
 
@@ -296,13 +294,14 @@ function plot3d(plotobj::DisplazWindow, position; color=[1,1,1], markersize=[0.1
     linebreak = interpret_linebreak(nvertices, linebreak)
     size(position, 1) == 3 || error("position must be a 3xN array")
     size(color, 1)    == 3 || error("color must be a 3xN array")
-    # FIXME in displaz itself.  No repmat waste should be required.
+    # FIXME in displaz itself.  No repeat waste should be required.
     if size(color,2) == 1
-        color = repmat(color, 1, nvertices)
+        color = repeat(color, 1, nvertices)
     end
 
-    extra_fields = map(x -> (size(x[2]) == (nvertices,) || error("extra fields must be vectors of same length as number of points in position array") ;
-                                        (x[1], array_semantic, map(Float32, x[2]).')), kwargs) # works for vectors only at this stage...
+    # works for vectors only at this stage...
+    extra_fields = ((x -> (size(x[2]) == (nvertices,) || error("extra fields must be vectors of same length as number of points in position array") ;
+        (x[1], array_semantic, transpose(Float32.(x[2])))) for x = pairs(kwargs)))
 
     # Ensure all fields are floats for now, to avoid surprising scaling in the
     # shader
@@ -319,11 +318,11 @@ function plot3d(plotobj::DisplazWindow, position; color=[1,1,1], markersize=[0.1
         write_ply_lines(filename, position, color, linebreak)
     else # Plot points
         if length(markersize) == 1
-            markersize = repmat(markersize, 1, nvertices)
+            markersize = repeat(markersize, 1, nvertices)
         end
         markershape = interpret_shape(markershape)
         if length(markershape) == 1
-            markershape = repmat(markershape, 1, nvertices)
+            markershape = repeat(markershape, 1, nvertices)
         end
         write_ply_points(filename, nvertices, (
                          (:position, vector_semantic, position),
@@ -356,17 +355,17 @@ increasing speed).
 `position` attribute controls the vertex positions, and the remainder match
 the original plotting command.
 """
-function mutate!{I <: Integer}(label::AbstractString, index::AbstractVector{I}; kwargs...)
+function mutate!(label::AbstractString, index::AbstractVector{I}; kwargs...) where I <: Integer
     plotobj = _current_figure
     mutate!(plotobj, label, index; kwargs...)
 end
 
-function mutate!{I <: Integer}(plotobj::DisplazWindow, label::AbstractString, index::AbstractVector{I}; kwargs...)
+function mutate!(plotobj::DisplazWindow, label::AbstractString, index::AbstractVector{I}; kwargs...) where I <: Integer
     nvertices = length(index)
 
     fields = Vector{Any}()
 
-    push!(fields, (:index, array_semantic, map(UInt32, (index-1)'))) # It turns out the -1 is rather important (0-based indexing)... :)
+    push!(fields, (:index, array_semantic, map(UInt32, (index.-1)'))) # It turns out the -1 is rather important (0-based indexing)... :)
 
     for (fieldname, fielddata) ∈ kwargs
         if fieldname == :position
@@ -378,7 +377,7 @@ function mutate!{I <: Integer}(plotobj::DisplazWindow, label::AbstractString, in
             fielddata = interpret_color(fielddata)
             size(fielddata, 1) == 3 || error("color must be a 3xN array")
             if size(fielddata,2) == 1
-                fielddata = repmat(fielddata, 1, nvertices)
+                fielddata = repeat(fielddata, 1, nvertices)
             end
             size(fielddata) == (3,nvertices,) || error("wrong number of color points")
             fielddata = map(Float32, fielddata)
@@ -386,7 +385,7 @@ function mutate!{I <: Integer}(plotobj::DisplazWindow, label::AbstractString, in
             push!(fields, (:color, color_semantic, fielddata))
         elseif fieldname == :markershape
             if length(fielddata) == 1
-                fielddata = repmat(fielddata, 1, nvertices)
+                fielddata = repeat(fielddata, 1, nvertices)
             end
             size(fielddata) == (nvertices,) || error("wrong number of markershape points")
             fielddata = interpret_shape(fielddata)
@@ -394,14 +393,14 @@ function mutate!{I <: Integer}(plotobj::DisplazWindow, label::AbstractString, in
             push!(fields, (:markershape, array_semantic, vec(fielddata)'))
         elseif fieldname == :linebreak
             if length(fielddata) == 1
-                fielddata = repmat(fielddata, 1, nvertices)
+                fielddata = repeat(fielddata, 1, nvertices)
             end
             fielddata = interpret_linebreak(fielddata)
 
             push!(fields, (:linebreak, array_semantic, vec(fielddata)'))
         else
             if length(fielddata) == 1
-                fielddata = repmat(fielddata, nvertices)
+                fielddata = repeat(fielddata, nvertices)
             end
             size(fielddata) == (nvertices,) || error("extra fields must be vectors of same length as index array")
             fielddata = map(Float32, fielddata)
@@ -568,14 +567,14 @@ viewplot(; kwargs...) = viewplot(current(); kwargs...)
 
 # viewplot() helper stuff
 # center
-viewplot_center_args(::Void) = []
+viewplot_center_args(::Nothing) = []
 viewplot_center_args(s::AbstractString) = ["-viewlabel", string(s)]
 viewplot_center_args(pos) = ["-viewposition", string(pos[1]), string(pos[2]), string(pos[3])]
 # rotation
-viewplot_rotation_args(::Void) = []
+viewplot_rotation_args(::Nothing) = []
 viewplot_rotation_args(M) = vcat("-viewrotation", map(string, vec(Matrix(M)'))) # Generate row-major order
 # radius
-viewplot_radius_args(::Void) = []
+viewplot_radius_args(::Nothing) = []
 viewplot_radius_args(r) = ["-viewradius", string(r)]
 
 

--- a/src/events.jl
+++ b/src/events.jl
@@ -1,13 +1,13 @@
 # Hooks and event loop functionality
 
-immutable KeyEvent
+struct KeyEvent
     spec::AbstractString
 end
 
 import Base: ==
 ==(e1::KeyEvent, e2::KeyEvent) = e1.spec == e2.spec
 
-immutable CursorPosition
+struct CursorPosition
     pos::SVector{3,Float64}
 end
 
@@ -15,7 +15,7 @@ _eventspec_str(s::AbstractString) = s
 _eventspec_str(e::KeyEvent) = "key:$(e.spec)"
 
 _argspec_str(s::AbstractString) = s
-_argspec_str(::Type{Void}) = "null"
+_argspec_str(::Type{Nothing}) = "null"
 _argspec_str(::Type{CursorPosition}) = "cursor"
 
 
@@ -28,12 +28,12 @@ Each event comes with some optional some state which is attached at the time
 the event is triggered.  The events are specified as a list of `event=>state`
 pairs.
 
-Currently only `KeyEvent` is supported, with the possible arguments `Void` or
+Currently only `KeyEvent` is supported, with the possible arguments `Nothing` or
 `CursorPosition`.  For example:
 
 ```
 Displaz.event_loop(
-        KeyEvent("c")=>Void,
+        KeyEvent("c")=>Nothing,
         KeyEvent("p")=>CursorPosition
 ) do event, arg
     @show event, arg
@@ -78,4 +78,4 @@ end
 event_loop(callback::Function, event_list...) = event_loop(callback, current(), event_list...)
 
 # Wait until the given displaz event occurs
-Base.wait(event::KeyEvent) = event_loop((e,a)->false, event=>Void)
+Base.wait(event::KeyEvent) = event_loop((e,a)->false, event=>Nothing)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Displaz
-using Base.Test
+using Test
 
 # write your own tests here
 @test 1 == 1


### PR DESCRIPTION
Updated julia syntax and fixed deprecation warnings. With this locally I can run the `point_spiral.jl` example (pretty!) and the README code.

Woops, only just saw that there was also a `ajf/julia-1.0` branch. Changes there are mostly the same, this is slightly more extensive, also updating CI.