### PR TITLE
allow for annotations

### DIFF
--- a/src/Displaz.jl
+++ b/src/Displaz.jl
@@ -448,6 +448,7 @@ text is the text to plot and label its Displaz label, note annotation labels don
 they are needed however to unload an annotation. If unspecified the label defaults to the annotation string.
 """
 function annotation(plotobj::DisplazWindow, coords::Array{T,1}, text::String, label=text::String) where {T<:Real}
+    length(coords) == 3 || throw(ArgumentError("Length of coordinate vector must be 3"))
     run_displaz(`-script -server $(plotobj.name) -annotation $text $(coords[1]) $(coords[2]) $(coords[3]) -label $label`)
     nothing
 end

--- a/src/Displaz.jl
+++ b/src/Displaz.jl
@@ -447,7 +447,7 @@ If not specified, `plotobj` is the current plot window.  coords is a three eleme
 text is the text to plot and label its Displaz label, note annotation labels don't appear in Displaz's list of data sets
 they are needed however to unload an annotation. If unspecified the label defaults to the annotation string.
 """
-function annotation(plotobj::DisplazWindow, coords::Array{T,1}, text::String, label=text::String)
+function annotation(plotobj::DisplazWindow, coords::Vector{<:Real}, text::String, label=text::String)
     length(coords) == 3 || throw(ArgumentError("Length of coordinate vector must be 3"))
     run_displaz(`-script -server $(plotobj.name) -annotation $text $(coords[1]) $(coords[2]) $(coords[3]) -label $label`)
     nothing

--- a/src/Displaz.jl
+++ b/src/Displaz.jl
@@ -439,13 +439,13 @@ plot3d(position; kwargs...)  = plot3d(current(), position; kwargs...)
 
 #-------------------------------------------------------------------------------
 """
-    annotation([plotobj::DisplazWindow=current()], coords::Array{Real,1}, annotation::String)
+    annotation(plotobj::DisplazWindow, coords::Array{T,1}, text::String, label=text::String)
 
 Place a text annotation at given coordinates
 
 If not specified, `plotobj` is the current plot window.  coords is a three element array [x, y, z],
-text is the text to plot and label its displaz label, note annotation labels dont' appear in Displaz's list of data sets
-they are needed however to unload an annotation. If unspecified the label deaults to the annotation string.
+text is the text to plot and label its Displaz label, note annotation labels don't appear in Displaz's list of data sets
+they are needed however to unload an annotation. If unspecified the label defaults to the annotation string.
 """
 function annotation(plotobj::DisplazWindow, coords::Array{T,1}, text::String, label=text::String) where {T<:Real}
     run_displaz(`-script -server $(plotobj.name) -annotation $text $(coords[1]) $(coords[2]) $(coords[3]) -label $label`)

--- a/src/Displaz.jl
+++ b/src/Displaz.jl
@@ -439,7 +439,7 @@ plot3d(position; kwargs...)  = plot3d(current(), position; kwargs...)
 
 #-------------------------------------------------------------------------------
 """
-    annotation(plotobj::DisplazWindow, coords::Array{T,1}, text::String, label=text::String)
+    annotation([plotobj::DisplazWindow,] coords::Array{T,1}, text::String, label=text::String)
 
 Place a text annotation at given coordinates
 

--- a/src/Displaz.jl
+++ b/src/Displaz.jl
@@ -2,7 +2,7 @@ module Displaz
 using StaticArrays
 using Colors
 
-export plot3d, plot3d!, plotimage, plotimage!, clearplot, viewplot
+export plot3d, plot3d!, plotimage, plotimage!, clearplot, viewplot, annotation
 export KeyEvent, CursorPosition, event_loop
 
 """
@@ -435,6 +435,25 @@ end
 # Plot to current window
 plot3d!(position; kwargs...) = plot3d!(current(), position; kwargs...)
 plot3d(position; kwargs...)  = plot3d(current(), position; kwargs...)
+
+
+#-------------------------------------------------------------------------------
+"""
+    annotation([plotobj::DisplazWindow=current()], coords::Array{Real,1}, annotation::String)
+
+Place a text annotation at given coordinates
+
+If not specified, `plotobj` is the current plot window.  coords is a three element array [x, y, z],
+text is the text to plot and label its displaz label, note annotation labels dont' appear in Displaz's list of data sets
+they are needed however to unload an annotation. If unspecified the label deaults to the annotation string.
+"""
+function annotation(plotobj::DisplazWindow, coords::Array{T,1}, text::String, label=text::String) where {T<:Real}
+    run_displaz(`-script -server $(plotobj.name) -annotation $text $(coords[1]) $(coords[2]) $(coords[3]) -label $label`)
+    nothing
+end
+annotation(coords::Array{T,1}, text::String, label::String) where {T<:Real} = annotation(current(), coords, text, label)
+annotation(coords::Array{T,1}, text::String) where {T<:Real} = annotation(current(), coords, text)
+annotation(text::String, coords::Array{T,1}) where {T<:Real} = annotation(current(), coords, text)
 
 
 #-------------------------------------------------------------------------------

--- a/src/Displaz.jl
+++ b/src/Displaz.jl
@@ -447,12 +447,8 @@ If not specified, `plotobj` is the current plot window.  coords is a three eleme
 text is the text to plot and label its Displaz label, note annotation labels don't appear in Displaz's list of data sets
 they are needed however to unload an annotation. If unspecified the label defaults to the annotation string.
 """
-<<<<<<< Updated upstream
-function annotation(plotobj::DisplazWindow, coords::Array{T,1}, text::String, label=text::String) where {T<:Real}
+function annotation(plotobj::DisplazWindow, coords::Array{T,1}, text::String, label=text::String)
     length(coords) == 3 || throw(ArgumentError("Length of coordinate vector must be 3"))
-=======
-function annotation(plotobj::DisplazWindow, coords::Vector{<:Real}, text::AbstractString, label=text::AbstractString)
->>>>>>> Stashed changes
     run_displaz(`-script -server $(plotobj.name) -annotation $text $(coords[1]) $(coords[2]) $(coords[3]) -label $label`)
     nothing
 end

--- a/src/Displaz.jl
+++ b/src/Displaz.jl
@@ -447,14 +447,17 @@ If not specified, `plotobj` is the current plot window.  coords is a three eleme
 text is the text to plot and label its Displaz label, note annotation labels don't appear in Displaz's list of data sets
 they are needed however to unload an annotation. If unspecified the label defaults to the annotation string.
 """
+<<<<<<< Updated upstream
 function annotation(plotobj::DisplazWindow, coords::Array{T,1}, text::String, label=text::String) where {T<:Real}
     length(coords) == 3 || throw(ArgumentError("Length of coordinate vector must be 3"))
+=======
+function annotation(plotobj::DisplazWindow, coords::Vector{<:Real}, text::AbstractString, label=text::AbstractString)
+>>>>>>> Stashed changes
     run_displaz(`-script -server $(plotobj.name) -annotation $text $(coords[1]) $(coords[2]) $(coords[3]) -label $label`)
     nothing
 end
-annotation(coords::Array{T,1}, text::String, label::String) where {T<:Real} = annotation(current(), coords, text, label)
-annotation(coords::Array{T,1}, text::String) where {T<:Real} = annotation(current(), coords, text)
-annotation(text::String, coords::Array{T,1}) where {T<:Real} = annotation(current(), coords, text)
+annotation(coords::Vector{<:Real}, text::AbstractString, label::AbstractString) = annotation(current(), coords, text, label)
+annotation(coords::Vector{<:Real}, text::AbstractString) = annotation(current(), coords, text)
 
 
 #-------------------------------------------------------------------------------

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,3 +46,7 @@ end
           `-script -server default -viewposition 1 2 3 -viewradius 4 -viewangles 5 6 7`
 end
 
+@testset "annotation" begin
+    @test @displaz_args(annotation("Hello world", [0, 1, 2])) == `-script -server default -annotation "Hello world" 0 1 2 -label "Hello world"`
+    @test @displaz_args(annotation([0, 1, 2], "Hello world", "A label")) == `-script -server default -annotation "Hello world" 0 1 2 -label "A label"`
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,6 +47,6 @@ end
 end
 
 @testset "annotation" begin
-    @test @displaz_args(annotation("Hello world", [0, 1, 2])) == `-script -server default -annotation "Hello world" 0 1 2 -label "Hello world"`
+    @test @displaz_args(annotation([0, 1, 2], "Hello world")) == `-script -server default -annotation "Hello world" 0 1 2 -label "Hello world"`
     @test @displaz_args(annotation([0, 1, 2], "Hello world", "A label")) == `-script -server default -annotation "Hello world" 0 1 2 -label "A label"`
 end


### PR DESCRIPTION
Simply creates a function allowing one to access Displaz's ability to place text annotations